### PR TITLE
Add leave mission feature

### DIFF
--- a/src/Components/Mission.js
+++ b/src/Components/Mission.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { joinMission } from '../redux/mission/missionSlice';
+import { joinMission, leaveMission } from '../redux/mission/missionSlice';
 
 const Mission = ({
   id, name, description, reserved,
@@ -12,13 +12,17 @@ const Mission = ({
       <th className="heading" scope="row">{name}</th>
       <td className="heading col-lg-7">{description}</td>
       <td className="btns">
-        <span className="badge text-bg-secondary">Not A Member</span>
+        {reserved ? (
+          <span className="badge text-bg-primary">Active Member</span>
+        ) : (<span className="badge text-bg-secondary">Not A Member</span>
+        )}
       </td>
       <td className="btns">
         {reserved ? (
           <button
             type="button"
             className="btn btn-outline-danger btn-sm"
+            onClick={() => dispatch(leaveMission(id))}
           >
             Leave Mission
           </button>

--- a/src/redux/mission/missionSlice.js
+++ b/src/redux/mission/missionSlice.js
@@ -28,6 +28,12 @@ const missionSlice = createSlice({
         mission.reserved = !mission.reserved;
       }
     },
+    leaveMission: (state, action) => {
+      const mission = state.missions.find((mission) => mission.id === action.payload);
+      if (mission) {
+        mission.reserved = !mission.reserved;
+      }
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(fetchMissions.pending,
@@ -51,5 +57,5 @@ const missionSlice = createSlice({
       });
   },
 });
-export const { joinMission } = missionSlice.actions;
+export const { joinMission, leaveMission } = missionSlice.actions;
 export default missionSlice.reducer;


### PR DESCRIPTION
- Follow the same logic as with the "Join mission" but set the reserved key to false.
- Dispatch these actions upon clicking on the corresponding buttons.
- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
